### PR TITLE
Fix first connection attempt error

### DIFF
--- a/gateway.py
+++ b/gateway.py
@@ -366,8 +366,8 @@ try:
         client.on_connect = on_connect
         client.on_message = on_message
         
-        client.connect(orgID+".messaging.internetofthings.ibmcloud.com", 1883, 15)
         client.username_pw_set("use-token-auth", auth_token)
+        client.connect(orgID+".messaging.internetofthings.ibmcloud.com", 1883, 15)
     
     
     


### PR DESCRIPTION
changed the order of two lines,` client.username_pw_set` and `client.connect`, so that authentication is already supported, when the connection is settled the first time.